### PR TITLE
Bump nodeBB version to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Shipped version:** 4.0.1~ynh1
+**Shipped version:** 4.0.2~ynh1
 
 **Demo:** <https://try.nodebb.org>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Versión actual:** 4.0.1~ynh1
+**Versión actual:** 4.0.2~ynh1
 
 **Demo:** <https://try.nodebb.org>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Paketatutako bertsioa:** 4.0.1~ynh1
+**Paketatutako bertsioa:** 4.0.2~ynh1
 
 **Demoa:** <https://try.nodebb.org>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Il NE doit PAS être modifié à la main.
 
 NodeBB est construit à l'aide de la plateforme Javascript côté serveur Node.js, offrant des performances inégalées. S'appuyer sur cette plateforme hautes performances signifie des performances rapides et fiables qui prendront en charge même la communauté la plus importante et la plus active.
 
-**Version incluse :** 4.0.1~ynh1
+**Version incluse :** 4.0.2~ynh1
 
 **Démo :** <https://try.nodebb.org>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Versión proporcionada:** 4.0.1~ynh1
+**Versión proporcionada:** 4.0.2~ynh1
 
 **Demo:** <https://try.nodebb.org>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Versi terkirim:** 4.0.1~ynh1
+**Versi terkirim:** 4.0.2~ynh1
 
 **Demo:** <https://try.nodebb.org>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Geleverde versie:** 4.0.1~ynh1
+**Geleverde versie:** 4.0.2~ynh1
 
 **Demo:** <https://try.nodebb.org>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Dostarczona wersja:** 4.0.1~ynh1
+**Dostarczona wersja:** 4.0.2~ynh1
 
 **Demo:** <https://try.nodebb.org>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**Поставляемая версия:** 4.0.1~ynh1
+**Поставляемая версия:** 4.0.2~ynh1
 
 **Демо-версия:** <https://try.nodebb.org>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 NodeBB is built using the Node.js server-side Javascript platform, delivering unmatched performance.
 Building on this high performance platform means fast and dependable performance that will support even the biggest and most active community.
 
-**分发版本：** 4.0.1~ynh1
+**分发版本：** 4.0.2~ynh1
 
 **演示：** <https://try.nodebb.org>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "NodeBB"
 description.en = "Forum software built for the modern web"
 description.fr = "Logiciel de forum conçu pour le Web moderne"
 
-version = "4.0.1~ynh1"
+version = "4.0.2~ynh1"
 
 maintainers = []
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "NodeBB"
 description.en = "Forum software built for the modern web"
 description.fr = "Logiciel de forum conçu pour le Web moderne"
 
-version = "4.0.2~ynh1"
+version = "4.1.0~ynh1"
 
 maintainers = []
 


### PR DESCRIPTION
## Problem

NodeBB upgrade is pretty straigforward: get the latest code from the release branch (v4.x currently). But this upgrade doesn't trigger if the version number in the manifest isn't updated.. which I just did.

## Solution

Update package version number in the manifest.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
