### PR TITLE
fix module_not_found issue preventing install

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -42,7 +42,7 @@ setup="{
 	}"
 
 pushd $install_dir
-	npm install npm@latest --location=global
+	npm install npm@10 --location=global
 	ynh_exec_as_app npm install lodash --save
 	ynh_exec_as_app $install_dir/nodebb setup "${setup}" 2>/dev/null
 popd

--- a/tests.toml
+++ b/tests.toml
@@ -16,4 +16,4 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    test_upgrade_from.f3a9c4d1221089d7eb36052d61d06945ea00238e.name = "Upgrade from 4.0.1~ynh1"
+    #test_upgrade_from.f3a9c4d1221089d7eb36052d61d06945ea00238e.name = "Upgrade from 4.0.1~ynh1"


### PR DESCRIPTION
## Problem
- CI and manual install throwing error on fresh install:
```
24535 WARNING npm error code MODULE_NOT_FOUND
24535 WARNING npm error Cannot find module 'promise-retry'
24536 WARNING npm error Require stack:
24536 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
24536 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/index.js
24542 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/index.js
24542 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/node_modules/libnpmfund/lib/index.js
24542 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/lib/utils/reify-output.js
24543 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/lib/utils/reify-finish.js
24543 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/lib/commands/install.js
24544 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/lib/npm.js
24544 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/lib/cli/entry.js
24545 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/lib/cli.js
24545 WARNING npm error - /opt/node_n/n/versions/node/22.22.2/lib/node_modules/npm/bin/npm-cli.js
```

## Solution

- switch to npm@10 from npm@latest

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
